### PR TITLE
Adjust objects in OpenShift template to enable applying the rendered template with kubectl

### DIFF
--- a/template/openshift-prometheus-proxy.yaml
+++ b/template/openshift-prometheus-proxy.yaml
@@ -22,6 +22,8 @@ objects:
   metadata:
     name: view:openshift-prometheus-proxy
   roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
     name: view
   subjects:
   - kind: ServiceAccount

--- a/template/openshift-prometheus-proxy.yaml
+++ b/template/openshift-prometheus-proxy.yaml
@@ -3,7 +3,7 @@ kind: Template
 metadata:
   name: openshift-prometheus-proxy
 objects:
-- apiVersion: v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
   metadata:
     name: access-openshift-prometheus-proxy
@@ -16,7 +16,7 @@ objects:
     - services
     verbs:
     - get
-- apiVersion: v1
+- apiVersion: rbac.authorization.k8s.io/v1
   groupNames: null
   kind: RoleBinding
   metadata:
@@ -33,7 +33,7 @@ objects:
     labels:
       app: openshift-prometheus-proxy
     name: openshift-prometheus-proxy
-- apiVersion: v1
+- apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
     labels:
@@ -52,7 +52,7 @@ objects:
       name: latest
       referencePolicy:
         type: Source
-- apiVersion: v1
+- apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
     name: ose-oauth-proxy
@@ -69,7 +69,7 @@ objects:
       name: latest
       referencePolicy:
         type: Source
-- apiVersion: v1
+- apiVersion: image.openshift.io/v1
   kind: ImageStream
   metadata:
     labels:
@@ -78,7 +78,7 @@ objects:
   spec:
     lookupPolicy:
       local: false
-- apiVersion: v1
+- apiVersion: build.openshift.io/v1
   kind: BuildConfig
   metadata:
     labels:


### PR DESCRIPTION
When rendering the template with `oc`, but managing the resulting manifests with GitOps (e.g. ArgoCD) or when rendering the template through other means (e.g. as a Commodore component for Project Syn, cf. https://github.com/appuio/component-openshift-prometheus-proxy), the `apiVersion: v1` shorthand for RBAC objects, ImageStreams and BuildConfigs does not pass the manifest verification present in modern versions of `kubectl`.

Additionally, modern `kubectl` also complains about the missing `apiGroup` field in the RoleBinding's `roleRef`.

This PR ajdusts the OpenShift template to use explicitly grouped apiVersions and changes the RoleBinding to explictly refer to the `view` ClusterRole.